### PR TITLE
feat: Added client.telescope.initialise() route handler.

### DIFF
--- a/src/routes/telescope.ts
+++ b/src/routes/telescope.ts
@@ -61,6 +61,17 @@ export const telescope = (
         const url = new URL('telescope/config', base)
         return dispatchRequest<T>(url, init, headers)
       }
+    },
+    {
+      name: 'initialise',
+      action: <
+        T = {
+          connected: boolean
+        }
+      >() => {
+        const url = new URL('telescope/init', base)
+        return dispatchRequest<T>(url, { ...init, method: 'PUT' }, headers)
+      }
     }
   ] as const
 

--- a/tests/mocks/telescope.ts
+++ b/tests/mocks/telescope.ts
@@ -6,7 +6,7 @@
 
 /*****************************************************************************************************************/
 
-import { eventHandler } from 'h3'
+import { eventHandler, getMethod } from 'h3'
 
 import { type Handler } from '../shared/handler'
 
@@ -48,6 +48,24 @@ export const telescopeHandlers: Handler[] = [
         apertureArea: 0.0269,
         apertureDiameter: 0.0269,
         focalLength: 1.26
+      }
+    })
+  },
+  {
+    method: 'PUT',
+    url: '/api/v1/telescope/init',
+    handler: eventHandler(event => {
+      const method = getMethod(event)
+
+      if (method !== 'PUT') {
+        return new Response('Method Not Allowed', {
+          status: 405,
+          statusText: 'Method Not Allowed'
+        })
+      }
+
+      return {
+        connected: true
       }
     })
   }

--- a/tests/telescopeRoutes.spec.ts
+++ b/tests/telescopeRoutes.spec.ts
@@ -42,5 +42,11 @@ suite('@observerly/hyper Fiber API Telescope Client', () => {
       expect(apertureDiameter).toBe(0.0269)
       expect(focalLength).toBe(1.26)
     })
+
+    it('should be able to initialise the telescope', async () => {
+      const client = setupClient(getURL('/api/v1/'))
+      const { connected } = await client.telescope.initialise()
+      expect(connected).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
feat: Added client.telescope.initialise() route handler. 

Includes associated test suite for module export definition and expected output from API route.