### PR TITLE
fix: Ensure correct T = { fastReadOut } type for client.camera.getFastReadOutMode.

### DIFF
--- a/src/routes/camera.ts
+++ b/src/routes/camera.ts
@@ -79,7 +79,7 @@ export const camera = (base: URL, init?: RequestInit, headers?: () => Promise<He
       name: 'getFastReadOutMode',
       action: <
         T = {
-          fastReadoutMode: boolean
+          fastReadOut: boolean
         }
       >() => {
         const url = new URL('camera/fastreadout', base)


### PR DESCRIPTION
fix: Ensure correct T = { fastReadOut } type for client.camera.getFastReadOutMode.