### PR TITLE
fix: Amend client.camera.startExposure() route handler with correct ResponseType<T>.

### DIFF
--- a/src/routes/camera.ts
+++ b/src/routes/camera.ts
@@ -178,7 +178,14 @@ export const camera = (base: URL, init?: RequestInit, headers?: () => Promise<He
     },
     {
       name: 'startExposure',
-      action: <T = {}>(body: {
+      action: <
+        T = {
+          duration: number
+          flat: boolean
+          dark: boolean
+          light: boolean
+        }
+      >(body: {
         duration: number
         flat: boolean
         dark: boolean


### PR DESCRIPTION
fix: Amend client.camera.startExposure() route handler with correct ResponseType<T>. Includes associated test suite for module export definition and expected output from API route.