### PR TITLE
feat: add client.camera.disconnect() route handler to @observerly/hyper.

### DIFF
--- a/src/routes/camera.ts
+++ b/src/routes/camera.ts
@@ -161,6 +161,29 @@ export const camera = (base: URL, init?: RequestInit, headers?: () => Promise<He
       }
     },
     {
+      name: 'disconnect',
+      action: <
+        T = {
+          connected: boolean
+        }
+      >() => {
+        const url = new URL('camera/connect', base)
+
+        const data = JSON.stringify({ connect: false })
+
+        return dispatchRequest<T>(
+          url,
+          {
+            ...init,
+            method: 'PUT',
+            body: JSON.stringify({ connect: false })
+          },
+          headers,
+          data
+        )
+      }
+    },
+    {
       name: 'turnCoolerOn',
       action: <
         T = {

--- a/tests/camera.spec.ts
+++ b/tests/camera.spec.ts
@@ -34,6 +34,14 @@ suite('@observerly/hyper Fiber API Observing Camera Client', () => {
       expect(status).toStrictEqual({ connected: true })
     })
 
+    it('should be able to disconnect the camera', async () => {
+      const client = setupClient(getURL('/api/v1/'))
+      const status = await client.camera.disconnect()
+      expect(isDataResult(status)).toBe(true)
+      if (!isDataResult(status)) return
+      expect(status).toStrictEqual({ connected: false })
+    })
+
     it('should be able to get the configuration of the camera', async () => {
       const client = setupClient(getURL('/api/v1/'))
       const configuration = await client.camera.getConfiguration()


### PR DESCRIPTION
feat: add client.camera.disconnect() route handler to @observerly/hyper. 

---

Includes associated test suite for module export definition and expected output from API route.