### PR TITLE
refactor: amend client.dome.couple() and decouple() in @observerly/hyper.

### DIFF
--- a/src/routes/dome.ts
+++ b/src/routes/dome.ts
@@ -191,14 +191,14 @@ export const dome = (base: URL, init?: RequestInit, headers?: () => Promise<Head
       >() => {
         const url = new URL('dome/couple', base)
 
-        const data = JSON.stringify({ couple: true })
+        const data = JSON.stringify({ couple: true, uncouple: false })
 
         return dispatchRequest<T>(
           url,
           {
             ...init,
             method: 'PUT',
-            body: JSON.stringify({ couple: true })
+            body: JSON.stringify({ couple: true, uncouple: false })
           },
           headers,
           data
@@ -214,14 +214,14 @@ export const dome = (base: URL, init?: RequestInit, headers?: () => Promise<Head
       >() => {
         const url = new URL('dome/couple', base)
 
-        const data = JSON.stringify({ couple: false })
+        const data = JSON.stringify({ couple: false, uncouple: true })
 
         return dispatchRequest<T>(
           url,
           {
             ...init,
             method: 'PUT',
-            body: JSON.stringify({ couple: false })
+            body: JSON.stringify({ couple: false, uncouple: true })
           },
           headers,
           data
@@ -229,3 +229,5 @@ export const dome = (base: URL, init?: RequestInit, headers?: () => Promise<Head
       }
     }
   ] as const
+
+/*****************************************************************************************************************/

--- a/tests/domeRoutes.spec.ts
+++ b/tests/domeRoutes.spec.ts
@@ -102,7 +102,7 @@ suite('@observerly/hyper Fiber API Dome Client', () => {
       const couple = await client.dome.couple()
       expect(isDataResult(couple)).toBe(true)
       if (!isDataResult(couple)) return
-      expect(couple).toStrictEqual({ coupled: true })
+      expect(couple).toStrictEqual({ coupled: true, uncouple: false })
     })
 
     it('should be able to decouple the dome from the telescope', async () => {
@@ -110,7 +110,7 @@ suite('@observerly/hyper Fiber API Dome Client', () => {
       const uncouple = await client.dome.decouple()
       expect(isDataResult(uncouple)).toBe(true)
       if (!isDataResult(uncouple)) return
-      expect(uncouple).toStrictEqual({ coupled: false })
+      expect(uncouple).toStrictEqual({ coupled: false, uncouple: true })
     })
 
     it('should be able to shutdown the dome', async () => {

--- a/tests/mocks/dome.ts
+++ b/tests/mocks/dome.ts
@@ -140,7 +140,7 @@ export const domeHandlers: Handler[] = [
         })
       }
 
-      const body = await readBody<{ couple: boolean }>(event)
+      const body = await readBody<{ couple: boolean; uncouple: boolean }>(event)
 
       if (!body) {
         return new Response('Bad Request', {
@@ -150,7 +150,8 @@ export const domeHandlers: Handler[] = [
       }
 
       return {
-        coupled: body.couple
+        coupled: body.couple,
+        uncouple: body.uncouple
       }
     })
   },


### PR DESCRIPTION
refactor: amend client.dome.couple() and decouple() in @observerly/hyper.