### PR TITLE
feat: add client.exposure.start() router handler.

### DIFF
--- a/src/routes/exposure.ts
+++ b/src/routes/exposure.ts
@@ -28,6 +28,33 @@ export const exposure = (
         const url = new URL('exposure/ready', base)
         return dispatchRequest<T>(url, init, headers)
       }
+    },
+    {
+      name: 'start',
+      action: <
+        T = {
+          duration: number
+          flat: boolean
+          dark: boolean
+          light: boolean
+        }
+      >(body: {
+        duration: number
+        flat: boolean
+        dark: boolean
+        light: boolean
+      }) => {
+        const url = new URL('exposure/start', base)
+
+        const data = JSON.stringify(body)
+
+        return dispatchRequest<T>(
+          url,
+          { ...init, method: 'PUT', body: JSON.stringify(body) },
+          headers,
+          data
+        )
+      }
     }
   ] as const
 

--- a/tests/exposure.spec.ts
+++ b/tests/exposure.spec.ts
@@ -29,6 +29,24 @@ suite('@observerly/hyper NOX API Observing Exposure Client', () => {
         ready: true
       })
     })
+
+    it('should be able to start an exposure', async () => {
+      const client = setupClient(getURL('/api/v1/'))
+      const status = await client.exposure.start({
+        duration: 300,
+        dark: false,
+        flat: false,
+        light: true
+      })
+      expect(isDataResult(status)).toBe(true)
+      if (!isDataResult(status)) return
+      expect(status).toStrictEqual({
+        duration: 300,
+        dark: false,
+        flat: false,
+        light: true
+      })
+    })
   })
 })
 

--- a/tests/mocks/exposure.ts
+++ b/tests/mocks/exposure.ts
@@ -6,7 +6,7 @@
 
 /*****************************************************************************************************************/
 
-import { eventHandler } from 'h3'
+import { eventHandler, getMethod, readBody } from 'h3'
 
 import { type Handler } from '../shared/handler'
 
@@ -21,6 +21,41 @@ export const exposureHandlers: Handler[] = [
         complete: true,
         progress: 100,
         ready: true
+      }
+    })
+  },
+  {
+    method: ['PUT'],
+    url: '/api/v1/exposure/start',
+    handler: eventHandler(async event => {
+      const method = getMethod(event)
+
+      if (method !== 'PUT') {
+        return new Response('Method Not Allowed', {
+          status: 405,
+          statusText: 'Method Not Allowed'
+        })
+      }
+
+      const body = await readBody<{
+        duration: number
+        flat: boolean
+        dark: boolean
+        light: boolean
+      }>(event)
+
+      if (!body) {
+        return new Response('Bad Request', {
+          status: 400,
+          statusText: 'Bad Request'
+        })
+      }
+
+      return {
+        duration: body.duration,
+        flat: body.flat,
+        dark: body.dark,
+        light: body.light
       }
     })
   }


### PR DESCRIPTION
feat: add client.exposure.start() router handler.

---

 Includes associated test suite for module export definition and expected output from API route.