### PR TITLE
feat: add client.exposure.stop() router handler.

### DIFF
--- a/src/routes/exposure.ts
+++ b/src/routes/exposure.ts
@@ -55,6 +55,14 @@ export const exposure = (
           data
         )
       }
+    },
+    {
+      name: 'stop',
+      action: <T = {}>() => {
+        const url = new URL('exposure/stop', base)
+
+        return dispatchRequest<T>(url, { ...init, method: 'DELETE' }, headers)
+      }
     }
   ] as const
 

--- a/tests/exposure.spec.ts
+++ b/tests/exposure.spec.ts
@@ -47,6 +47,14 @@ suite('@observerly/hyper NOX API Observing Exposure Client', () => {
         light: true
       })
     })
+
+    it('should be able to stop an exposure', async () => {
+      const client = setupClient(getURL('/api/v1/'))
+      const status = await client.exposure.stop()
+      expect(isDataResult(status)).toBe(true)
+      if (!isDataResult(status)) return
+      expect(status).toStrictEqual({})
+    })
   })
 })
 

--- a/tests/mocks/exposure.ts
+++ b/tests/mocks/exposure.ts
@@ -58,6 +58,22 @@ export const exposureHandlers: Handler[] = [
         light: body.light
       }
     })
+  },
+  {
+    method: ['DELETE'],
+    url: '/api/v1/exposure/stop',
+    handler: eventHandler(async event => {
+      const method = getMethod(event)
+
+      if (method !== 'DELETE') {
+        return new Response('Method Not Allowed', {
+          status: 405,
+          statusText: 'Method Not Allowed'
+        })
+      }
+
+      return {}
+    })
   }
 ]
 


### PR DESCRIPTION
feat: add client.exposure.stop() router handler. 

---

Includes associated test suite for module export definition and expected output from API route.