### PR TITLE
feat: add client.exposure.store() router handler.

### DIFF
--- a/src/routes/exposure.ts
+++ b/src/routes/exposure.ts
@@ -10,6 +10,28 @@ import { dispatchRequest } from '../internals/dispatchRequest'
 
 /*****************************************************************************************************************/
 
+export type ExposureStorePayload = {
+  bucketName: string
+  userId: string
+  uuid: string
+  duration: number
+  start: string
+  filter: string
+  isDark: boolean
+  isFlat: boolean
+  mimetype: string
+  target: string
+  mjd: number
+  equinox: number
+  ra: number
+  dec: number
+  telescope: string
+  instrument: string
+  observer: string
+}
+
+/*****************************************************************************************************************/
+
 export const exposure = (
   base: URL,
   init?: RequestInit,
@@ -62,6 +84,36 @@ export const exposure = (
         const url = new URL('exposure/stop', base)
 
         return dispatchRequest<T>(url, { ...init, method: 'DELETE' }, headers)
+      }
+    },
+    {
+      name: 'store',
+      action: <
+        T = {
+          ccdXSize: number
+          ccdYSize: number
+          isDark: boolean
+          isFlat: boolean
+          locations: string[]
+          maxADU: number
+          mimetype: string
+          sensor: string
+          userId: string
+          uuid: string
+        }
+      >(
+        body: ExposureStorePayload
+      ) => {
+        const url = new URL('exposure/store', base)
+
+        const data = JSON.stringify(body)
+
+        return dispatchRequest<T>(
+          url,
+          { ...init, method: 'POST', body: JSON.stringify(body) },
+          headers,
+          data
+        )
       }
     }
   ] as const

--- a/tests/exposure.spec.ts
+++ b/tests/exposure.spec.ts
@@ -55,6 +55,45 @@ suite('@observerly/hyper NOX API Observing Exposure Client', () => {
       if (!isDataResult(status)) return
       expect(status).toStrictEqual({})
     })
+
+    it('should be able to store an exposure from the camera', async () => {
+      const client = setupClient(getURL('/api/v1/'))
+      const store = await client.camera.storeExposure({
+        bucketName: 'test.ex.observerly.com',
+        duration: 130,
+        start: '2021-05-15T03:00:00.000Z',
+        filter: 'Hα',
+        isDark: false,
+        isFlat: false,
+        mimetype: 'application/fits',
+        target: 'M42',
+        userId: 'sK0EFowNCXQ0JOK4UES2AjSnrVc2',
+        uuid: '01H3WK0383PNKTT0240B53JX5N',
+        mjd: 59379.0,
+        equinox: 2021.5,
+        ra: 83.82208,
+        dec: -5.39111,
+        telescope: 'Namibiascope 1',
+        instrument: '20" AG Optical iDK Planewave L-500s',
+        observer: 'Michael Roberts'
+      })
+      expect(isDataResult(store)).toBe(true)
+      if (!isDataResult(store)) return
+      expect(store).toStrictEqual({
+        ccdXSize: 1463,
+        ccdYSize: 1168,
+        isDark: false,
+        isFlat: false,
+        locations: [
+          'gs://test.ex.observerly.com/sK0EFowNCXQ0JOK4UES2AjSnrVc2/01H3WK0383PNKTT0240B53JX5N/M42_[Hα]_monochrome_M_130s_2021-05-15T03:00:00.000Z.fits'
+        ],
+        maxADU: 65535,
+        mimetype: 'application/fits',
+        sensor: 'Monochrome',
+        userId: 'sK0EFowNCXQ0JOK4UES2AjSnrVc2',
+        uuid: '01H3WK0383PNKTT0240B53JX5N'
+      })
+    })
   })
 })
 

--- a/tests/mocks/exposure.ts
+++ b/tests/mocks/exposure.ts
@@ -10,6 +10,8 @@ import { eventHandler, getMethod, readBody } from 'h3'
 
 import { type Handler } from '../shared/handler'
 
+import { type ExposureStorePayload } from '../../src/routes/exposure'
+
 /*****************************************************************************************************************/
 
 export const exposureHandlers: Handler[] = [
@@ -73,6 +75,44 @@ export const exposureHandlers: Handler[] = [
       }
 
       return {}
+    })
+  },
+  {
+    method: ['POST'],
+    url: '/api/v1/exposure/store',
+    handler: eventHandler(async event => {
+      const method = getMethod(event)
+
+      if (method !== 'POST') {
+        return new Response('Method Not Allowed', {
+          status: 405,
+          statusText: 'Method Not Allowed'
+        })
+      }
+
+      const body = await readBody<ExposureStorePayload>(event)
+
+      if (!body) {
+        return new Response('Bad Request', {
+          status: 400,
+          statusText: 'Bad Request'
+        })
+      }
+
+      return {
+        ccdXSize: 1463,
+        ccdYSize: 1168,
+        isDark: body.isDark,
+        isFlat: body.isFlat,
+        locations: [
+          `gs://${body.bucketName}/${body.userId}/${body.uuid}/${body.target}_[${body.filter}]_monochrome_M_${body.duration}s_2021-05-15T03:00:00.000Z.fits`
+        ],
+        maxADU: 65535,
+        mimetype: body.mimetype,
+        sensor: 'Monochrome',
+        userId: body.userId,
+        uuid: body.uuid
+      }
     })
   }
 ]


### PR DESCRIPTION
feat: add client.exposure.store() router handler. 

---

Includes associated test suite for module export definition and expected output from API route.